### PR TITLE
changing first argument as "path" from "transformed_img" while calling "make_record" function in searh_image function.

### DIFF
--- a/image_match/signature_database_base.py
+++ b/image_match/signature_database_base.py
@@ -270,7 +270,7 @@ class SignatureDatabaseBase(object):
             transformed_img = transform(img)
 
             # generate the signature
-            transformed_record = make_record(transformed_img, self.gis, self.k, self.N)
+            transformed_record = make_record(path, self.gis, self.k, self.N)
 
             l = self.search_single_record(transformed_record, pre_filter=pre_filter)
             result.extend(l)


### PR DESCRIPTION
This solves the "ValueError: the input array must have size 3 along `channel_axis`, got (1269, 1920)" error while searching the image
![channel axis (error) - make_record - error](https://user-images.githubusercontent.com/97912085/160252397-e1cc57b6-e930-4761-82de-95150a144ba2.JPG)
.